### PR TITLE
Update busuanzi url

### DIFF
--- a/layout/includes/partial/head.pug
+++ b/layout/includes/partial/head.pug
@@ -33,4 +33,4 @@ head
   script(src="https://cdnjs.cloudflare.com/ajax/libs/fancybox/3.2.5/jquery.fancybox.min.js" defer)
   // busuanzi
   if (theme.count.busuanzi)
-    script(async src="//dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js")
+    script(async src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js")


### PR DESCRIPTION
The old url `//dn-lbstatics.qbox.me/busuanzi/2.3/busuanzi.pure.mini.js` is out of date, see: http://ibruce.info/2015/04/04/busuanzi/